### PR TITLE
Fixes CONTRIB-4597

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -1664,7 +1664,7 @@ table#user-grades .catlevel1,
 table#user-grades .catlevel2,
 table#user-grades .catlevel3,
 table#user-grades .catlevel4 {
-	padding: 10px;
+	padding: 0px 10px;
 	border-right: 1px solid #ddd;
 }
 


### PR DESCRIPTION
https://tracker.moodle.org/browse/CONTRIB-4597

Misalignment of student names/grades (off by 1+ row) when grade_report_fixedstudents
is enabled.
