### PR TITLE
Fixes CONTRIB-4601

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -1622,14 +1622,14 @@ width: 67%;
 .mform .fitem div.fitemtitle, 
 .userprofile dl.list dt, 
 .form-horizontal .control-label { 
-	width: 90px; 
+	width: 150px; 
 }
 
 .form-item .form-setting, 
 .form-item .form-description, 
 .mform .fitem .felement, 
 #page-mod-forum-search .c1 { 
-	margin-left: 10px; 
+	margin-left: 250px; 
 }
 
 /* @end */


### PR DESCRIPTION
https://tracker.moodle.org/browse/CONTRIB-4601

Adjusted the 'width' of form-item to make the settings/values not overlap

I don't think this breaks anything else; I did a spot check, but not being overly familiar
with the theme, will let the theme creator decide.
