### PR TITLE
Fixes an additional bug I found on Contrib 4597

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -1779,7 +1779,7 @@ table#user-grades th.userreport.c1 {
 }
 
 .path-grade-report-grader .right_scroller table#user-grades td.grade{
-    height:5em
+    height: 5em;
 }
 
 /* @end */

--- a/style/custom.css
+++ b/style/custom.css
@@ -1773,6 +1773,15 @@ table#user-grades th.userreport.c1 {
 	width: 5px;
 }
 
+
+.path-grade-report-grader .left_scroller #fixed_column th {
+    height: 5em;
+}
+
+.path-grade-report-grader .right_scroller table#user-grades td.grade{
+    height:5em
+}
+
 /* @end */
 
 /* @group Alerts */


### PR DESCRIPTION
https://tracker.moodle.org/browse/CONTRIB-4597

If the fixedstudent flag is set, and the edit mode is turned on, the
rows are off by 2-3 every 50 rows in the grader report. Off by a full row
after the first ~11 rows.

As always, this comes with a disclaimer that I'm not a theme designer. The below fix seems
to work for me, but please use at your discretion.

*Additional commit needed to fix missing semicolon.
