### PR TITLE
Not a bug fix - a suggestion from a non-designer:

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -431,7 +431,7 @@ h2.pagetitle span {
 }
 
 .container-fluid {
-    max-width: 1200px;
+    max-width: 1800px;
 }
 
 #region-main {


### PR DESCRIPTION
Most people utilize wide screen monitors today. By changing the
.container-fluid: max-width from 1200px to 1800px, there is a
better chance of fitting more "stuff" on the screen.

At my institution, several instructors had issues with the amount
of screen real estate that Essential would use. Even if the browser
were maximized, there was much horizontal scrolling, particularly
when grading an assignment or using the Grader Report.

I don't believe increasing this value to 1800px changes the view
on a small screen, and allows those with wide screens to see
more "stuff".

Again, this is not a bug fix, but a suggestion from someone who
has been supporting users who have been happy with Essential for
the past month.
