### PR TITLE
Add to the user the ability to choose alternatives colours defined by administrators

### DIFF
--- a/config.php
+++ b/config.php
@@ -33,7 +33,7 @@ $THEME->name = 'essential';
 $THEME->doctype = 'html5';
 $THEME->yuicssmodules = array();
 $THEME->parents = array('bootstrapbase');
-$THEME->sheets = array('slides', 'categories', 'font-awesome.min', 'essential', 'settings');
+$THEME->sheets = array('slides', 'categories', 'font-awesome.min', 'essential', 'alternative1', 'alternative2', 'alternative3', 'settings');
 $THEME->supportscssoptimisation = false;
 $THEME->enable_dock = false;
 
@@ -162,6 +162,7 @@ $THEME->layouts = array(
 );
 
 $THEME->javascripts = array(
+    'coloursswitcher'
 );
 
 $THEME->javascripts_footer = array(

--- a/javascript/coloursswitcher.js
+++ b/javascript/coloursswitcher.js
@@ -1,0 +1,66 @@
+YUI.add('moodle-theme_essential-coloursswitcher', function(Y) {
+
+// Available color schemes.
+var SCHEMES = ['default', 'alternative1', 'alternative2', 'alternative3'];
+
+/**
+ * Essential theme colours switcher class.
+ * Initialise this class by calling M.theme_essential.init
+ */
+var ColoursSwitcher = function() {
+    ColoursSwitcher.superclass.constructor.apply(this, arguments);
+};
+ColoursSwitcher.prototype = {
+    /**
+     * Constructor for this class
+     * @param {object} config
+     */
+    initializer : function(config) {
+        var i, s;
+        // Attach events to the links to change colours scheme so we can do it with
+        // JavaScript without refreshing the page.
+        for (i in SCHEMES) {
+            s = SCHEMES[i];
+            // Check if this is the current colour.
+            if (Y.one(document.body).hasClass('essential-colours-' + s)) {
+                this.set('scheme', s);
+            }
+            Y.all(config.div + ' .colours-' + s).each(function(node) {
+                node.ancestor().on('click', this.setScheme, this, s);
+            }, this);
+        }
+    },
+    /**
+     * Sets the colour being used for the essential theme
+     * @param {Y.Event} e The event that fired
+     * @param {string} colours The new colours scheme
+     */
+    setScheme : function(e, scheme) {
+        // Prevent the event from refreshing the page.
+        e.preventDefault();
+        // Switch over the CSS classes on the body.
+        var prefix = 'essential-colours-';
+        Y.one(document.body).replaceClass(prefix + this.get('scheme'), prefix + scheme);
+        // Update the current colour.
+        this.set('scheme', scheme);
+        // Store the users selection (Uses AJAX to save to the database).
+        M.util.set_user_preference('theme_essential_colours', scheme);
+    }
+};
+// Make the colours switcher a fully fledged YUI module.
+Y.extend(ColoursSwitcher, Y.Base, ColoursSwitcher.prototype, {
+    NAME : 'Essential theme colours scheme switcher',
+    ATTRS : {
+        scheme: {
+            value : 'default'
+        }
+    }
+});
+// Our Essential theme namespace
+M.theme_essential = M.theme_essential || {};
+// Initialisation function for the colours scheme switcher
+M.theme_essential.initColoursSwitcher = function(cfg) {
+    return new ColoursSwitcher(cfg);
+}
+
+}, '@VERSION@', {requires:['base','node']});

--- a/lang/en/theme_essential.php
+++ b/lang/en/theme_essential.php
@@ -182,6 +182,18 @@ $string['footerheadingcolordesc'] = 'Set the colour for block headings in the fo
 $string['pagebackground'] = 'Page Background Image';
 $string['pagebackgrounddesc'] = 'Upload your own background image.  This will be tiled in the background on all pages.  If none is uploaded a default image is used.';
 
+$string['alternativecolors'] = 'Alternative Colours {$a}';
+$string['alternativethemecolor'] = 'Alternative Theme Colour {$a}';
+$string['alternativethemecolordesc'] = 'What colour should your theme be for the alternative theme colours {$a}. If enabled and the user choose it, this will replace the default theme colour.';
+$string['alternativethemecolors'] = 'Alternative Theme Colours';
+$string['alternativethemecolorsdesc'] = 'Defines theme colours alternative that the user may select.';
+$string['alternativethemehovercolor'] = 'Alternative Theme Hover Colour {$a}';
+$string['alternativethemehovercolordesc'] = 'What colour should your theme hovers be for the alternative theme colours {$a}. If enabled and the user choose it, this will replace the default theme hover colour.';
+$string['defaultcolors'] = 'Default Colours';
+$string['enablealternativethemecolors'] = 'Enable Alternative Theme Colours {$a}';
+$string['enablealternativethemecolorsdesc'] = 'If enabled, the user will be able to choose the alternative theme colours {$a}.';
+$string['themecolors'] = 'Theme Colours';
+
 /* Frontpage Settings */
 $string['frontcontentheading'] = 'Frontpage Settings';
 $string['frontcontentheadingsub'] = 'Change what features you wish enabled on your moodle front page';

--- a/lang/en_us/theme_essential.php
+++ b/lang/en_us/theme_essential.php
@@ -50,3 +50,16 @@ $string['footerhovercolor'] = 'Footer Link Hover Color';
 $string['footerhovercolordesc'] = 'Set the color for your linked text when hovered over in the footer.';
 $string['footerheadingcolor'] = 'Footer Heading Color';
 $string['footerheadingcolordesc'] = 'Set the color for block headings in the footer.';
+
+$string['alternativecolors'] = 'Alternative Colors {$a}';
+$string['alternativethemecolor'] = 'Alternative Theme Color {$a}';
+$string['alternativethemecolordesc'] = 'What color should your theme be for the alternative theme colors {$a}. If enabled and the user choose it, this will replace the default theme color.';
+$string['alternativethemecolors'] = 'Alternative Theme Colors';
+$string['alternativethemecolorsdesc'] = 'Defines theme colors alternative that the user may select.';
+$string['alternativethemehovercolor'] = 'Alternative Theme Hover Color {$a}';
+$string['alternativethemehovercolordesc'] = 'What color should your theme hovers be for the alternative theme colors {$a}. If enabled and the user choose it, this will replace the default theme hover color.';
+$string['defaultcolors'] = 'Default Colors';
+$string['enablealternativethemecolors'] = 'Enable Alternative Theme Colors {$a}';
+$string['enablealternativethemecolorsdesc'] = 'If enabled, the user will be able to choose the alternative theme colors {$a}.';
+$string['themecolors'] = 'Theme Colors';
+

--- a/layout/columns1.php
+++ b/layout/columns1.php
@@ -28,6 +28,12 @@ $haslogo = (!empty($PAGE->theme->settings->logo));
 $hasboringlayout = (empty($PAGE->theme->settings->layout)) ? false : $PAGE->theme->settings->layout;
 $hasanalytics = (empty($PAGE->theme->settings->useanalytics)) ? false : $PAGE->theme->settings->useanalytics;
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
@@ -41,7 +47,7 @@ echo $OUTPUT->doctype() ?>
     <?php require_once(dirname(__FILE__).'/includes/iosicons.php'); ?>
 </head>
 
-<body <?php echo $OUTPUT->body_attributes(); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -28,6 +28,13 @@ $haslogo = (!empty($PAGE->theme->settings->logo));
 $hasboringlayout = (empty($PAGE->theme->settings->layout)) ? false : $PAGE->theme->settings->layout;
 $hasanalytics = (empty($PAGE->theme->settings->useanalytics)) ? false : $PAGE->theme->settings->useanalytics;
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'two-column';
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 $left = (!right_to_left());  // To know if to add 'pull-right' and 'desktop-first-column' classes in the layout for LTR.
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
@@ -42,7 +49,7 @@ echo $OUTPUT->doctype() ?>
     <?php require_once(dirname(__FILE__).'/includes/iosicons.php'); ?>
 </head>
 
-<body <?php echo $OUTPUT->body_attributes('two-column'); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/layout/columns3.php
+++ b/layout/columns3.php
@@ -28,6 +28,12 @@ $haslogo = (!empty($PAGE->theme->settings->logo));
 $hasboringlayout = (empty($PAGE->theme->settings->layout)) ? false : $PAGE->theme->settings->layout;
 $hasanalytics = (empty($PAGE->theme->settings->useanalytics)) ? false : $PAGE->theme->settings->useanalytics;
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 if (right_to_left()) {
     $regionbsid = 'region-bs-main-and-post';
 } else {
@@ -47,7 +53,7 @@ echo $OUTPUT->doctype() ?>
     <?php require_once(dirname(__FILE__).'/includes/iosicons.php'); ?>
 </head>
 
-<body <?php echo $OUTPUT->body_attributes(); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/layout/embedded.php
+++ b/layout/embedded.php
@@ -14,6 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
@@ -23,7 +29,7 @@ echo $OUTPUT->doctype() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
-<body <?php echo $OUTPUT->body_attributes(); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 <div id="page">
     <div id="page-content" class="clearfix">

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -118,6 +118,13 @@ if ($hasslide4url) {
     $slide4url = $PAGE->theme->settings->slide4url;
 }
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'two-column';
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 $left = (!right_to_left());  // To know if to add 'pull-right' and 'desktop-first-column' classes in the layout for LTR.
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
@@ -135,7 +142,7 @@ echo $OUTPUT->doctype() ?>
     <?php require_once(dirname(__FILE__).'/includes/iosicons.php'); ?>
 </head>
 
-<body <?php echo $OUTPUT->body_attributes('two-column'); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/layout/maintenance.php
+++ b/layout/maintenance.php
@@ -24,6 +24,12 @@
  * breaking installation or upgrade unwittingly.
  */
 
+theme_essential_check_colours_switch();
+theme_essential_initialise_colourswitcher($PAGE);
+
+$bodyclasses = array();
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
@@ -33,7 +39,7 @@ echo $OUTPUT->doctype() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
-<body <?php echo $OUTPUT->body_attributes(); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/layout/secure.php
+++ b/layout/secure.php
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+$bodyclasses = array();
+$bodyclasses[] = 'essential-colours-' . theme_essential_get_colours();
+
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
@@ -23,7 +26,7 @@ echo $OUTPUT->doctype() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
-<body <?php echo $OUTPUT->body_attributes(); ?>>
+<body <?php echo $OUTPUT->body_attributes($bodyclasses); ?>>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 

--- a/lib.php
+++ b/lib.php
@@ -414,7 +414,17 @@ function theme_essential_process_css($css, $theme) {
     }
     $css = theme_essential_set_slidebuttoncolor($css, $slidebuttoncolor);
 
-    
+    // Set theme alternative colors.
+    $defaultalternativethemecolors = array('#a430d1', '#d15430', '#5dd130');
+    $defaultalternativethemehovercolors = array('#9929c4', '#c44c29', '#53c429');
+
+    foreach (range(1, 3) as $alternativethemenumber) {
+        $default = $defaultalternativethemecolors[$alternativethemenumber - 1];
+        $defaulthover = $defaultalternativethemehovercolors[$alternativethemenumber - 1];
+        $css = theme_essential_set_alternativecolor($css, 'color' . $alternativethemenumber, $theme->settings->{'alternativethemecolor' . $alternativethemenumber}, $default);
+        $css = theme_essential_set_alternativecolor($css, 'hovercolor' . $alternativethemenumber, $theme->settings->{'alternativethemehovercolor' . $alternativethemenumber}, $defaulthover);
+    }
+
     // Set the navbar seperator.
     if (!empty($theme->settings->navbarsep)) {
         $navbarsep = $theme->settings->navbarsep;
@@ -541,6 +551,52 @@ function theme_essential_process_css($css, $theme) {
     return $css;
 }
 
+/**
+ * Adds the JavaScript for the colour switcher to the page.
+ *
+ * The colour switcher is a YUI moodle module that is located in
+ *     theme/udemspl/yui/udemspl/udemspl.js
+ *
+ * @param moodle_page $page
+ */
+function theme_essential_initialise_colourswitcher(moodle_page $page) {
+    user_preference_allow_ajax_update('theme_essential_colours', PARAM_ALPHANUM);
+    $page->requires->yui_module(
+        'moodle-theme_essential-coloursswitcher',
+        'M.theme_essential.initColoursSwitcher',
+        array(array('div' => '.dropdown-menu'))
+    );
+}
+
+/**
+ * Gets the theme colors the user has selected if enabled or the default if they have never changed
+ *
+ * @param string $default The default theme colors to use
+ * @return string The theme colors the user has selected
+ */
+function theme_essential_get_colours($default = 'default') {
+    $theme = theme_config::load('essential');
+    $preference = get_user_preferences('theme_essential_colours', $default);
+    foreach (range(1, 3) as $alternativethemenumber) {
+        if ($preference == 'alternative' . $alternativethemenumber && !empty($theme->settings->{'enablealternativethemecolors' . $alternativethemenumber})) {
+            return $preference;
+        }
+    }
+    return $default;
+}
+
+/**
+ * Checks if the user is switching colours with a refresh
+ *
+ * If they are this updates the users preference in the database
+ */
+function theme_essential_check_colours_switch() {
+    $colours= optional_param('essentialcolours', null, PARAM_ALPHANUM);
+    if (in_array($colours, array('default', 'alternative1', 'alternative2', 'alternative3'))) {
+        set_user_preference('theme_essential_colours', $colours);
+    }
+}
+
 function theme_essential_set_headingfont($css, $headingfont) {
     $tag = '[[setting:headingfont]]';
     $replacement = $headingfont;
@@ -596,6 +652,16 @@ function theme_essential_set_themehovercolor($css, $themehovercolor) {
     $replacement = $themehovercolor;
     if (is_null($replacement)) {
         $replacement = '#29a1c4';
+    }
+    $css = str_replace($tag, $replacement, $css);
+    return $css;
+}
+
+function theme_essential_set_alternativecolor($css, $type, $customcolor, $defaultcolor) {
+    $tag = '[[setting:alternativetheme' . $type . ']]';
+    $replacement = $customcolor;
+    if (is_null($replacement)) {
+        $replacement = $defaultcolor;
     }
     $css = str_replace($tag, $replacement, $css);
     return $css;

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -144,6 +144,34 @@
  			$branch->add('<em><i class="fa fa-file"></i>'.get_string('privatefiles', 'block_private_files').'</em>',new moodle_url('/user/files.php'),get_string('privatefiles', 'block_private_files'));
  			$branch->add('<em><i class="fa fa-sign-out"></i>'.get_string('logout').'</em>',new moodle_url('/login/logout.php'),get_string('logout'));    
         }
+
+        /*
+         * This code adds the Theme colors selector to the custommenu.
+         */
+        if (isloggedin() && !isguestuser()) {
+            $alternativethemes = array();
+            foreach (range(1, 3) as $alternativethemenumber) {
+                if (!empty($this->page->theme->settings->{'enablealternativethemecolors' . $alternativethemenumber})) {
+                    $alternativethemes[] = $alternativethemenumber;
+                }
+            }
+            if (!empty($alternativethemes)) {
+                $branchtitle = get_string('themecolors', 'theme_essential');
+                $branchlabel = '<i class="fa fa-th-large"></i>' . $branchtitle;
+                $branchurl   = new moodle_url('/my/index.php');
+                $branchsort  = 10000;
+                $branch = $menu->add($branchlabel, $branchurl, $branchtitle, $branchsort);
+                
+                $defaultthemecolorslabel = get_string('defaultcolors', 'theme_essential');
+                $branch->add('<i class="fa fa-square colours-default"></i>' . $defaultthemecolorslabel,
+                        new moodle_url($this->page->url, array('essentialcolours' => 'default')), $defaultthemecolorslabel);
+                foreach ($alternativethemes as $alternativethemenumber) {
+                    $alternativethemeslabel = get_string('alternativecolors', 'theme_essential', $alternativethemenumber);
+                    $branch->add('<i class="fa fa-square colours-alternative' .  $alternativethemenumber . '"></i>' . $alternativethemeslabel,
+                            new moodle_url($this->page->url, array('essentialcolours' => 'alternative' . $alternativethemenumber)), $alternativethemeslabel);
+                }
+            }
+        }
  
         return parent::render_custom_menu($menu);
     }

--- a/settings.php
+++ b/settings.php
@@ -369,7 +369,47 @@ defined('MOODLE_INTERNAL') || die;
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
 
+    // This is the descriptor for the user theme colors.
+    $name = 'theme_essential/alternativethemecolorsinfo';
+    $heading = get_string('alternativethemecolors', 'theme_essential');
+    $information = get_string('alternativethemecolorsdesc', 'theme_essential');
+    $setting = new admin_setting_heading($name, $heading, $information);
+    $temp->add($setting);
 
+    $defaultalternativethemecolors = array('#a430d1', '#d15430', '#5dd130');
+    $defaultalternativethemehovercolors = array('#9929c4', '#c44c29', '#53c429');
+
+    foreach (range(1, 3) as $alternativethemenumber) {
+
+        // Enables the user to select an alternative colors choice.
+        $name = 'theme_essential/enablealternativethemecolors' . $alternativethemenumber;
+        $title = get_string('enablealternativethemecolors', 'theme_essential', $alternativethemenumber);
+        $description = get_string('enablealternativethemecolorsdesc', 'theme_essential', $alternativethemenumber);
+        $default = false;
+        $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $temp->add($setting);
+
+        // User theme colour setting.
+        $name = 'theme_essential/alternativethemecolor' . $alternativethemenumber;
+        $title = get_string('alternativethemecolor', 'theme_essential', $alternativethemenumber);
+        $description = get_string('alternativethemecolordesc', 'theme_essential', $alternativethemenumber);
+        $default = $defaultalternativethemecolors[$alternativethemenumber - 1];
+        $previewconfig = null;
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, $default, $previewconfig);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $temp->add($setting);
+
+        // User theme hover colour setting.
+        $name = 'theme_essential/alternativethemehovercolor' . $alternativethemenumber;
+        $title = get_string('alternativethemehovercolor', 'theme_essential', $alternativethemenumber);
+        $description = get_string('alternativethemehovercolordesc', 'theme_essential', $alternativethemenumber);
+        $default = $defaultalternativethemehovercolors[$alternativethemenumber - 1];
+        $previewconfig = null;
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, $default, $previewconfig);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $temp->add($setting);
+    }
 
  	$ADMIN->add('theme_essential', $temp);
  

--- a/style/alternative1.css
+++ b/style/alternative1.css
@@ -1,0 +1,288 @@
+body.essential-colours-alternative1 {
+    border-top-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 a,
+.essential-colours-alternative1 a:visited {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 a:hover {
+    color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .color {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 h1#title {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #headerlogo {
+    border-right-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .breadcrumb-button input[type="submit"] {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .breadcrumb-button input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 a.website:hover,
+.essential-colours-alternative1 a.website:focus {
+    background-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .dropdown-menu > li > a:hover,
+.essential-colours-alternative1 .dropdown-menu > li > a:focus,
+.essential-colours-alternative1 .dropdown-submenu:hover > a,
+.essential-colours-alternative1 .dropdown-submenu:focus > a {
+    background-color: [[setting:alternativethemecolor1]];
+    background-image: -moz-linear-gradient(top, [[setting:alternativethemecolor1]], [[setting:alternativethemehovercolor1]]);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from([[setting:alternativethemecolor1]]), to([[setting:alternativethemehovercolor1]]));
+    background-image: -webkit-linear-gradient(top, [[setting:alternativethemecolor1]], [[setting:alternativethemehovercolor1]]);
+    background-image: -o-linear-gradient(top, [[setting:alternativethemecolor1]], [[setting:alternativethemehovercolor1]]);
+    background-image: linear-gradient(to bottom, [[setting:alternativethemecolor1]], [[setting:alternativethemehovercolor1]]);
+}
+    
+.essential-colours-alternative1 .navbar-inner {
+    border-top-color: [[setting:alternativethemehovercolor1]] !important;
+    border-bottom: 1px solid [[setting:alternativethemehovercolor1]] !important;
+    background-color: [[setting:alternativethemecolor1]] !important;
+}
+
+.essential-colours-alternative1 .navbar .nav {
+    border-right-color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .navbar .nav > li > a:hover {
+    background: [[setting:alternativethemehovercolor1]] !important;
+}
+
+.essential-colours-alternative1 .navbar .nav .active > a,
+.essential-colours-alternative1 .navbar .nav .active > a:hover,
+.essential-colours-alternative1 .navbar .nav .active > a:focus,
+.essential-colours-alternative1 .navbar .nav li.dropdown.open > .dropdown-toggle,
+.essential-colours-alternative1 .navbar .nav li.dropdown.active > .dropdown-toggle,
+.essential-colours-alternative1 .navbar .nav li.dropdown.open.active > .dropdown-toggle {
+    background: [[setting:alternativethemecolor1]] !important;
+}
+
+.essential-colours-alternative1 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .course-content ul.topics li.section.main.clearfix.current {
+    box-shadow: 0 0 10px [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .firstword {
+    color: [[setting:alternativethemecolor1]] !important;
+}
+    
+.essential-colours-alternative1 .forumpost .picture img {
+    box-shadow: 0 0 3px [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .forumpost .subject {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .button a,
+.essential-colours-alternative1 .button a:visited {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 a#button,
+.essential-colours-alternative1 a#button:visited {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 a#button:hover {
+    background: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .da-slider {
+	border-top-color: [[setting:alternativethemecolor1]];
+	border-bottom-color:  [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .block .header .title h2:before {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .block_rss_client .footer a {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .block_rss_client .footer a:hover {
+    background: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .block_login .footer a {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .block_login .footer a:hover {
+    background: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 #page-site-index h2.headingblock:before {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .service i {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #page-footer {
+    border-top-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #page-footer .footnote a,
+.essential-colours-alternative1 #page-footer .footnote a:visited {
+    color: [[setting:alternativethemecolor1]] !important;
+}
+
+.essential-colours-alternative1 #page-footer .block_html ul li:before,
+.essential-colours-alternative1 #greyboxright ul li:before {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #page-footer .tree_item.branch:before {
+    color: [[setting:alternativethemecolor1]];
+}
+    
+.essential-colours-alternative1 #page-footer .block_login input[type="submit"] {
+    background: [[setting:alternativethemecolor1]];
+}
+    
+.essential-colours-alternative1 #page-footer .block_login input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor1]];
+}
+    
+.essential-colours-alternative1 #page-footer .block_rss_client .content a {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .afeature:hover {
+    border-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .afmatter i {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .myprofileitem.picture:hover {
+    border-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .socials img:hover {
+    -webkit-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor1]];
+    -moz-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor1]];
+    box-shadow: 0 0 10px 0 [[setting:alternativethemecolor1]];
+}
+ 
+.essential-colours-alternative1 .nav-tabs > li > a {
+    background-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .nav-tabs > li > a:hover {
+    background-color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .nav-collapse {
+    border-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .performanceinfo var {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .performanceinfo h2:before {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #page-mod-quiz-edit .questionbankwindow.block div.header {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 table#user-grades th.item,
+.essential-colours-alternative1 table#user-grades th.categoryitem,
+.essential-colours-alternative1 table#user-grades th.courseitem {
+    border-bottom-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 table#user-grades td.controls,
+.essential-colours-alternative1 .path-grade-report-grader table tr.avg .cell,
+.essential-colours-alternative1 .path-grade-report-grader table tr.range .cell {
+    background-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .path-grade-report-grader table#fixed_column th {
+     border-right-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .back-to-top {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .course_category_tree .category[data-categoryid]:hover {
+    background: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .course_category_tree .category[data-categoryid] > .info > .categoryname a:before {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #dock {
+    background: [[setting:alternativethemecolor1]];
+}
+
+#dock .dockedtitle {
+    background-color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #dock .dockedtitle:hover,
+.essential-colours-alternative1 #dock .dockedtitle:focus,
+.essential-colours-alternative1 #dock .dockedtitle:active,
+.essential-colours-alternative1 #dock .dockedtitle.active,
+.essential-colours-alternative1 #dock .dockedtitle.disabled,
+.essential-colours-alternative1 #dock .dockedtitle[disabled] {
+    background-color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .commands {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .commands a:hover {
+    color: [[setting:alternativethemehovercolor1]];
+}
+
+.essential-colours-alternative1 .drag-handle::before {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .drag-handle a {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 #section_footer {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .nav_icon {
+    color: [[setting:alternativethemecolor1]];
+}
+
+.essential-colours-alternative1 .nav_icon:hover {
+    color: [[setting:alternativethemehovercolor1]];
+}

--- a/style/alternative2.css
+++ b/style/alternative2.css
@@ -1,0 +1,288 @@
+body.essential-colours-alternative2 {
+    border-top-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 a,
+.essential-colours-alternative2 a:visited {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 a:hover {
+    color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .color {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 h1#title {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #headerlogo {
+    border-right-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .breadcrumb-button input[type="submit"] {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .breadcrumb-button input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 a.website:hover,
+.essential-colours-alternative2 a.website:focus {
+    background-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .dropdown-menu > li > a:hover,
+.essential-colours-alternative2 .dropdown-menu > li > a:focus,
+.essential-colours-alternative2 .dropdown-submenu:hover > a,
+.essential-colours-alternative2 .dropdown-submenu:focus > a {
+    background-color: [[setting:alternativethemecolor2]];
+    background-image: -moz-linear-gradient(top, [[setting:alternativethemecolor2]], [[setting:alternativethemehovercolor2]]);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from([[setting:alternativethemecolor2]]), to([[setting:alternativethemehovercolor2]]));
+    background-image: -webkit-linear-gradient(top, [[setting:alternativethemecolor2]], [[setting:alternativethemehovercolor2]]);
+    background-image: -o-linear-gradient(top, [[setting:alternativethemecolor2]], [[setting:alternativethemehovercolor2]]);
+    background-image: linear-gradient(to bottom, [[setting:alternativethemecolor2]], [[setting:alternativethemehovercolor2]]);
+}
+    
+.essential-colours-alternative2 .navbar-inner {
+    border-top-color: [[setting:alternativethemehovercolor2]] !important;
+    border-bottom: 1px solid [[setting:alternativethemehovercolor2]] !important;
+    background-color: [[setting:alternativethemecolor2]] !important;
+}
+
+.essential-colours-alternative2 .navbar .nav {
+    border-right-color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .navbar .nav > li > a:hover {
+    background: [[setting:alternativethemehovercolor2]] !important;
+}
+
+.essential-colours-alternative2 .navbar .nav .active > a,
+.essential-colours-alternative2 .navbar .nav .active > a:hover,
+.essential-colours-alternative2 .navbar .nav .active > a:focus,
+.essential-colours-alternative2 .navbar .nav li.dropdown.open > .dropdown-toggle,
+.essential-colours-alternative2 .navbar .nav li.dropdown.active > .dropdown-toggle,
+.essential-colours-alternative2 .navbar .nav li.dropdown.open.active > .dropdown-toggle {
+    background: [[setting:alternativethemecolor2]] !important;
+}
+
+.essential-colours-alternative2 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .course-content ul.topics li.section.main.clearfix.current {
+    box-shadow: 0 0 10px [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .firstword {
+    color: [[setting:alternativethemecolor2]] !important;
+}
+    
+.essential-colours-alternative2 .forumpost .picture img {
+    box-shadow: 0 0 3px [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .forumpost .subject {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .button a,
+.essential-colours-alternative2 .button a:visited {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 a#button,
+.essential-colours-alternative2 a#button:visited {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 a#button:hover {
+    background: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .da-slider {
+	border-top-color: [[setting:alternativethemecolor2]];
+	border-bottom-color:  [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .block .header .title h2:before {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .block_rss_client .footer a {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .block_rss_client .footer a:hover {
+    background: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .block_login .footer a {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .block_login .footer a:hover {
+    background: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 #page-site-index h2.headingblock:before {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .service i {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #page-footer {
+    border-top-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #page-footer .footnote a,
+.essential-colours-alternative2 #page-footer .footnote a:visited {
+    color: [[setting:alternativethemecolor2]] !important;
+}
+
+.essential-colours-alternative2 #page-footer .block_html ul li:before,
+.essential-colours-alternative2 #greyboxright ul li:before {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #page-footer .tree_item.branch:before {
+    color: [[setting:alternativethemecolor2]];
+}
+    
+.essential-colours-alternative2 #page-footer .block_login input[type="submit"] {
+    background: [[setting:alternativethemecolor2]];
+}
+    
+.essential-colours-alternative2 #page-footer .block_login input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor2]];
+}
+    
+.essential-colours-alternative2 #page-footer .block_rss_client .content a {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .afeature:hover {
+    border-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .afmatter i {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .myprofileitem.picture:hover {
+    border-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .socials img:hover {
+    -webkit-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor2]];
+    -moz-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor2]];
+    box-shadow: 0 0 10px 0 [[setting:alternativethemecolor2]];
+}
+ 
+.essential-colours-alternative2 .nav-tabs > li > a {
+    background-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .nav-tabs > li > a:hover {
+    background-color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .nav-collapse {
+    border-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .performanceinfo var {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .performanceinfo h2:before {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #page-mod-quiz-edit .questionbankwindow.block div.header {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 table#user-grades th.item,
+.essential-colours-alternative2 table#user-grades th.categoryitem,
+.essential-colours-alternative2 table#user-grades th.courseitem {
+    border-bottom-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 table#user-grades td.controls,
+.essential-colours-alternative2 .path-grade-report-grader table tr.avg .cell,
+.essential-colours-alternative2 .path-grade-report-grader table tr.range .cell {
+    background-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .path-grade-report-grader table#fixed_column th {
+     border-right-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .back-to-top {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .course_category_tree .category[data-categoryid]:hover {
+    background: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .course_category_tree .category[data-categoryid] > .info > .categoryname a:before {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #dock {
+    background: [[setting:alternativethemecolor2]];
+}
+
+#dock .dockedtitle {
+    background-color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #dock .dockedtitle:hover,
+.essential-colours-alternative2 #dock .dockedtitle:focus,
+.essential-colours-alternative2 #dock .dockedtitle:active,
+.essential-colours-alternative2 #dock .dockedtitle.active,
+.essential-colours-alternative2 #dock .dockedtitle.disabled,
+.essential-colours-alternative2 #dock .dockedtitle[disabled] {
+    background-color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .commands {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .commands a:hover {
+    color: [[setting:alternativethemehovercolor2]];
+}
+
+.essential-colours-alternative2 .drag-handle::before {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .drag-handle a {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 #section_footer {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .nav_icon {
+    color: [[setting:alternativethemecolor2]];
+}
+
+.essential-colours-alternative2 .nav_icon:hover {
+    color: [[setting:alternativethemehovercolor2]];
+}

--- a/style/alternative3.css
+++ b/style/alternative3.css
@@ -1,0 +1,288 @@
+body.essential-colours-alternative3 {
+    border-top-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 a,
+.essential-colours-alternative3 a:visited {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 a:hover {
+    color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .color {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 h1#title {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #headerlogo {
+    border-right-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .breadcrumb-button input[type="submit"] {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .breadcrumb-button input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 a.website:hover,
+.essential-colours-alternative3 a.website:focus {
+    background-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .dropdown-menu > li > a:hover,
+.essential-colours-alternative3 .dropdown-menu > li > a:focus,
+.essential-colours-alternative3 .dropdown-submenu:hover > a,
+.essential-colours-alternative3 .dropdown-submenu:focus > a {
+    background-color: [[setting:alternativethemecolor3]];
+    background-image: -moz-linear-gradient(top, [[setting:alternativethemecolor3]], [[setting:alternativethemehovercolor3]]);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from([[setting:alternativethemecolor3]]), to([[setting:alternativethemehovercolor3]]));
+    background-image: -webkit-linear-gradient(top, [[setting:alternativethemecolor3]], [[setting:alternativethemehovercolor3]]);
+    background-image: -o-linear-gradient(top, [[setting:alternativethemecolor3]], [[setting:alternativethemehovercolor3]]);
+    background-image: linear-gradient(to bottom, [[setting:alternativethemecolor3]], [[setting:alternativethemehovercolor3]]);
+}
+    
+.essential-colours-alternative3 .navbar-inner {
+    border-top-color: [[setting:alternativethemehovercolor3]] !important;
+    border-bottom: 1px solid [[setting:alternativethemehovercolor3]] !important;
+    background-color: [[setting:alternativethemecolor3]] !important;
+}
+
+.essential-colours-alternative3 .navbar .nav {
+    border-right-color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .navbar .nav > li > a:hover {
+    background: [[setting:alternativethemehovercolor3]] !important;
+}
+
+.essential-colours-alternative3 .navbar .nav .active > a,
+.essential-colours-alternative3 .navbar .nav .active > a:hover,
+.essential-colours-alternative3 .navbar .nav .active > a:focus,
+.essential-colours-alternative3 .navbar .nav li.dropdown.open > .dropdown-toggle,
+.essential-colours-alternative3 .navbar .nav li.dropdown.active > .dropdown-toggle,
+.essential-colours-alternative3 .navbar .nav li.dropdown.open.active > .dropdown-toggle {
+    background: [[setting:alternativethemecolor3]] !important;
+}
+
+.essential-colours-alternative3 .navbar .nav > li > a {
+    border-left-color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .course-content ul.topics li.section.main.clearfix.current {
+    box-shadow: 0 0 10px [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .firstword {
+    color: [[setting:alternativethemecolor3]] !important;
+}
+    
+.essential-colours-alternative3 .forumpost .picture img {
+    box-shadow: 0 0 3px [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .forumpost .subject {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .button a,
+.essential-colours-alternative3 .button a:visited {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 a#button,
+.essential-colours-alternative3 a#button:visited {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 a#button:hover {
+    background: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .da-slider {
+	border-top-color: [[setting:alternativethemecolor3]];
+	border-bottom-color:  [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .block .header .title h2:before {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .block_rss_client .footer a {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .block_rss_client .footer a:hover {
+    background: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .block_login .footer a {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .block_login .footer a:hover {
+    background: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 #page-site-index h2.headingblock:before {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .service i {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #page-footer {
+    border-top-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #page-footer .footnote a,
+.essential-colours-alternative3 #page-footer .footnote a:visited {
+    color: [[setting:alternativethemecolor3]] !important;
+}
+
+.essential-colours-alternative3 #page-footer .block_html ul li:before,
+.essential-colours-alternative3 #greyboxright ul li:before {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #page-footer .tree_item.branch:before {
+    color: [[setting:alternativethemecolor3]];
+}
+    
+.essential-colours-alternative3 #page-footer .block_login input[type="submit"] {
+    background: [[setting:alternativethemecolor3]];
+}
+    
+.essential-colours-alternative3 #page-footer .block_login input[type="submit"]:hover {
+    background: [[setting:alternativethemehovercolor3]];
+}
+    
+.essential-colours-alternative3 #page-footer .block_rss_client .content a {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .afeature:hover {
+    border-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .afmatter i {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .myprofileitem.picture:hover {
+    border-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .socials img:hover {
+    -webkit-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor3]];
+    -moz-box-shadow: 0 0 10px 0 [[setting:alternativethemecolor3]];
+    box-shadow: 0 0 10px 0 [[setting:alternativethemecolor3]];
+}
+ 
+.essential-colours-alternative3 .nav-tabs > li > a {
+    background-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .nav-tabs > li > a:hover {
+    background-color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .nav-collapse {
+    border-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .performanceinfo var {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .performanceinfo h2:before {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #page-mod-quiz-edit .questionbankwindow.block div.header {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 table#user-grades th.item,
+.essential-colours-alternative3 table#user-grades th.categoryitem,
+.essential-colours-alternative3 table#user-grades th.courseitem {
+    border-bottom-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 table#user-grades td.controls,
+.essential-colours-alternative3 .path-grade-report-grader table tr.avg .cell,
+.essential-colours-alternative3 .path-grade-report-grader table tr.range .cell {
+    background-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .path-grade-report-grader table#fixed_column th {
+     border-right-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .back-to-top {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .course_category_tree .category[data-categoryid]:hover {
+    background: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .course_category_tree .category[data-categoryid] > .info > .categoryname a:before {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #dock {
+    background: [[setting:alternativethemecolor3]];
+}
+
+#dock .dockedtitle {
+    background-color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #dock .dockedtitle:hover,
+.essential-colours-alternative3 #dock .dockedtitle:focus,
+.essential-colours-alternative3 #dock .dockedtitle:active,
+.essential-colours-alternative3 #dock .dockedtitle.active,
+.essential-colours-alternative3 #dock .dockedtitle.disabled,
+.essential-colours-alternative3 #dock .dockedtitle[disabled] {
+    background-color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .commands {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .commands a:hover {
+    color: [[setting:alternativethemehovercolor3]];
+}
+
+.essential-colours-alternative3 .drag-handle::before {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .drag-handle a {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 #section_footer {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .nav_icon {
+    color: [[setting:alternativethemecolor3]];
+}
+
+.essential-colours-alternative3 .nav_icon:hover {
+    color: [[setting:alternativethemehovercolor3]];
+}

--- a/style/categories.css
+++ b/style/categories.css
@@ -121,7 +121,7 @@
 
 .course_category_tree .category[data-categoryid]>.info>.categoryname a:hover {
 	text-decoration: none;
-	color: #fff;
+	color: #fff !important;
 }
 
 .course_category_tree .category[data-categoryid]>.info>.categoryname a:before {
@@ -141,7 +141,7 @@
 }
 
 .course_category_tree .category[data-categoryid] > .info > .categoryname a:hover:before {
-	color: #fff;
+	color: #fff !important;
 }
  
 /* Upload the image from each category */ 

--- a/style/essential.css
+++ b/style/essential.css
@@ -247,6 +247,11 @@ ul.socials {
 
 /* @end */
 
+.dropdown-menu > li > a,
+.dropdown-menu > li > a:visited{
+    color: #333;
+}
+
 /* @group Custom Menu */
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus,
@@ -314,7 +319,7 @@ ul.breadcrumb li:last-child:after {
 }
 
 .navbar .brand {
-    color: #fff;
+    color: #fff !important;
     text-shadow: none;
     line-height: 20px;
 }

--- a/style/settings.css
+++ b/style/settings.css
@@ -105,6 +105,18 @@ a.website:hover, a.website:focus {
 
 /* @end */
 
+/* @group Theme Colors Menu */
+a .colours-default {color: [[setting:themecolor]]}
+a:hover .colours-default {color: [[setting:hovercolor]]}
+a .colours-alternative1 {color: [[setting:alternativethemecolor1]]}
+a:hover .colours-alternative1 {color: [[setting:alternativethemehovercolor1]]}
+a .colours-alternative2 {color: [[setting:alternativethemecolor2]]}
+a:hover .colours-alternative2 {color: [[setting:alternativethemehovercolor2]]}
+a .colours-alternative3 {color: [[setting:alternativethemecolor3]]}
+a:hover .colours-alternative3 {color: [[setting:alternativethemehovercolor3]]}
+
+/* @end */
+
 /* @group Navbar
  */
 

--- a/style/slides.css
+++ b/style/slides.css
@@ -91,7 +91,7 @@
 	top: 200px; /*depends on p height*/
 	border-radius: 15px;
 	box-shadow: 0px 1px 1px rgba(0,0,0,0.1);
-	color: #fff;
+	color: #fff !important;
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.2);
 	padding:3px 15px;
 	font-size: 15px;


### PR DESCRIPTION
This is based on the color picker by Caroline Kennedy included in the Moodle Splash theme.

This feature is disabled by default but site administrator may choose to enable up to 3 alternative colors scheme.
If enabled, a new menu will appear in the custom menu to select the alternative scheme.

Each scheme of alternative colors replaces the base color and the hover color.
