### PR TITLE
Hide categories icon 'collapsed' in course/index.php page

### DIFF
--- a/style/categories.css
+++ b/style/categories.css
@@ -44,6 +44,7 @@
 
 /* Hide icon 'collapsed' because it makes no sense here */ 
 .course_category_tree .category.with_children>.info>.categoryname,
+.course_category_tree .category.with_children.collapsed>.info>.categoryname,
 .course_category_tree .category>.info>.categoryname {
 	background: none;
 	padding-left: 0px;


### PR DESCRIPTION
Discovered with 2.6+ (Build: 20131205).  I have added the line instead of replace it for keep the compatibility with old versions.
