### PR TITLE
fix navigation tree '.tree_item.emptybranch', show empty folder

### DIFF
--- a/style/essential.css
+++ b/style/essential.css
@@ -789,6 +789,13 @@ table#greyboxleft h2 {
     margin-right: 5px;
 }
 
+.tree_item.emptybranch:before {
+    font-family: FontAwesome;
+    content: "\f114 ";
+    color: #d3d3d3;
+    margin-right: 5px;
+}
+/*
 .block_navigation.block li.depth_1 .tree_item.branch:before {
     content: "\f015 ";
 }
@@ -800,7 +807,7 @@ table#greyboxleft h2 {
 .block_navigation.block li.depth_2 {
     margin-left: -20px;
 }
-
+*/
 .collapsed .tree_item.branch:before {
     font-family: FontAwesome;
     content: "\f07b ";


### PR DESCRIPTION
Show an empty folder if the the folder in the navigation tree is empty. The current behavior is nothing to show.
