### PR TITLE
Styling missing for form-overridden

### DIFF
--- a/style/essential.css
+++ b/style/essential.css
@@ -1637,6 +1637,11 @@ img.profilepicture
     margin-left: 180px; 
 }
 
+.form-item .form-label .form-overridden {
+    font-size: 75%;
+    font-family: monospace;
+}
+
 /* @end */
 
 


### PR DESCRIPTION
There is no styling for form-overriden (that indicates a configuration item has been "forced" in config.php). This is a basic proposition for such a style.
