### PR TITLE
Update FontAwesome font face to use Moodle CSS filter.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -35,27 +35,6 @@
  */
 
 /**
- * Include the Awesome Font.
- */
-function theme_essential_set_fontwww($css) {
-    global $CFG, $PAGE;
-    if(empty($CFG->themewww)){
-        $themewww = $CFG->wwwroot."/theme";
-    } else {
-        $themewww = $CFG->themewww;
-    }
-    $tag = '[[setting:fontwww]]';
-    
-    $theme = theme_config::load('essential');
-    if (!empty($theme->settings->bootstrapcdn)) {
-    	$css = str_replace($tag, '//netdna.bootstrapcdn.com/font-awesome/4.0.0/fonts/', $css);
-    } else {
-    	$css = str_replace($tag, $themewww.'/essential/fonts/', $css);
-    }
-    return $css;
-}
-
-/**
  * Adds the logo to CSS.
  *
  * @param string $css The CSS.
@@ -504,7 +483,6 @@ function theme_essential_process_css($css, $theme) {
 
     // Set the font path.
 
-    $css = theme_essential_set_fontwww($css);
     return $css;
 }
 

--- a/style/essential.css
+++ b/style/essential.css
@@ -52,11 +52,16 @@ a {
  	font-style: normal !important;
  }
  
- @font-face {
-     font-family: 'FontAwesome'; 
-     font-weight: normal;
-     font-style: normal;
- }
+@font-face {
+    font-family: 'FontAwesome';
+    src: url([[font:theme|fontawesome-webfont.eot]]);
+    src: url([[font:theme|fontawesome-webfont.eot]]) format('embedded-opentype'),
+        url([[font:theme|fontawesome-webfont.woff]]) format('woff'),
+        url([[font:theme|fontawesome-webfont.ttf]]) format('truetype'),
+        url([[font:theme|fontawesome-webfont.svg]]) format('svg');
+    font-weight: normal;
+    font-style: normal;
+}
  
  /* @end */
  

--- a/style/settings.css
+++ b/style/settings.css
@@ -7,14 +7,14 @@
  /* @group Core */
 
 @font-face {
-    font-family: 'FontAwesome'; 
+    font-family: 'FontAwesome';
+    src: url([[font:theme|fontawesome-webfont.eot]]);
+    src: url([[font:theme|fontawesome-webfont.eot]]) format('embedded-opentype'),
+        url([[font:theme|fontawesome-webfont.woff]]) format('woff'),
+        url([[font:theme|fontawesome-webfont.ttf]]) format('truetype'),
+        url([[font:theme|fontawesome-webfont.svg]]) format('svg');
     font-weight: normal;
     font-style: normal;
-    src: url('[[setting:fontwww]]fontawesome-webfont.eot?v=4.0.0');
-    src: url('[[setting:fontwww]]fontawesome-webfont.eot?#iefix&v=4.0.0') format('embedded-opentype'), 
-      			url('[[setting:fontwww]]fontawesome-webfont.woff?v=4.0.0') format('woff'), 
-      			url('[[setting:fontwww]]fontawesome-webfont.ttf?v=4.0.0') format('truetype'), 
-      			url('[[setting:fontwww]]fontawesome-webfont.svg#fontawesomeregular?v=4.0.0') format('svg');
 }
 
 body{


### PR DESCRIPTION
Same as for 2.7. Removes css font processing built into theme so that Moodle's filter is used instead. Allows fontawesome to work from moodledata as well as wwwroot/theme
